### PR TITLE
fix slot value entry 18 grape typo

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -114,7 +114,7 @@ slot_value = {
     5: ("bar","grape","bar"), 6: ("grape","grape","bar"), 7: ("lemon","grape","bar"), 8: ("seven","grape","bar"),
     9: ("bar","lemon","bar"),10: ("grape","lemon","bar"),11: ("lemon","lemon","bar"),12: ("seven","lemon","bar"),
    13: ("bar","seven","bar"),14: ("grape","seven","bar"),15: ("lemon","seven","bar"),16: ("seven","seven","bar"),
-   17: ("bar","bar","grape"),18: ("grape","bar","грape"),19: ("lemon","bar","grape"),20: ("seven","bar","grape"),
+   17: ("bar","bar","grape"),18: ("grape","bar","grape"),19: ("lemon","bar","grape"),20: ("seven","bar","grape"),
    21: ("bar","grape","grape"),22: ("grape","grape","grape"),23: ("lemon","grape","grape"),24: ("seven","grape","grape"),
    25: ("bar","lemon","grape"),26: ("grape","lemon","grape"),27: ("lemon","lemon","grape"),28: ("seven","lemon","grape"),
    29: ("bar","seven","grape"),30: ("grape","seven","grape"),31: ("lemon","seven","grape"),32: ("seven","seven","grape"),


### PR DESCRIPTION
## Summary
- fix grape string in slot_value entry 18

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ef107fe048329aa80b77803282d50