### PR TITLE
docs: update jackpot phrase delay

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,7 +3,7 @@
 """
 Ludooman Bot — Telegram slot 🎰 tracker
 - Silent count of 🎰 spins in groups
-- On triple (jackpot) sends a random phrase from a preset list (with 2s delay)
+- On triple (jackpot) sends a random phrase from a preset list (with 4s delay)
 - SQLite stats (persistent with Railway Volume)
 - Commands: /mystats, /stats, /help
 


### PR DESCRIPTION
## Summary
- clarify jackpot notification delay is 4 seconds

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ef220da688329b8839672ac19d5d9