### PR TITLE
Add tests for slot value mapping and jackpot phrase cycle

### DIFF
--- a/tests/test_slot_value.py
+++ b/tests/test_slot_value.py
@@ -1,0 +1,23 @@
+import asyncio
+import bot
+
+
+def test_slot_value_symbols_exist():
+    symbols = {symbol for combo in bot.slot_value.values() for symbol in combo}
+    assert symbols <= set(bot.EMOJI)
+
+
+def test_get_next_jackpot_phrase_cycle():
+    bot._jackpot_cycle_remaining = []
+    bot._jackpot_cycle_lock = None
+
+    async def collect():
+        phrases = set()
+        for _ in range(len(bot.JACKPOT_PHRASES)):
+            phrase = await bot.get_next_jackpot_phrase()
+            assert phrase not in phrases
+            phrases.add(phrase)
+        return phrases
+
+    collected = asyncio.run(collect())
+    assert collected == set(bot.JACKPOT_PHRASES)


### PR DESCRIPTION
## Summary
- test that all symbols referenced in slot_value exist in EMOJI
- test that get_next_jackpot_phrase returns each phrase exactly once per cycle

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ef29e6eb88329b9007e009223d10d