### PR TITLE
Add random delay for near-jackpot responses

### DIFF
--- a/tests/test_jackpot_delay.py
+++ b/tests/test_jackpot_delay.py
@@ -1,0 +1,42 @@
+import asyncio
+import importlib
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+def test_jackpot_delay_env(monkeypatch):
+    monkeypatch.setenv("JACKPOT_DELAY", "2.5")
+    import bot
+    importlib.reload(bot)
+
+    class DummyMessage:
+        def __init__(self):
+            self.dice = SimpleNamespace(emoji="🎰", value=64)
+        async def reply_text(self, text):
+            pass
+
+    update = SimpleNamespace(
+        effective_message=DummyMessage(),
+        effective_user=SimpleNamespace(id=1, full_name="User", username="user"),
+        effective_chat=SimpleNamespace(id=1),
+    )
+    context = SimpleNamespace()
+
+    captured = {}
+
+    async def fake_sleep(delay):
+        captured['delay'] = delay
+
+    orig_sleep = asyncio.sleep
+    asyncio.sleep = fake_sleep
+    try:
+        asyncio.run(bot.on_dice(update, context))
+    finally:
+        asyncio.sleep = orig_sleep
+        monkeypatch.delenv("JACKPOT_DELAY", raising=False)
+        importlib.reload(bot)
+
+    assert captured['delay'] == 2.5

--- a/tests/test_near_jackpot.py
+++ b/tests/test_near_jackpot.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+import random
+import sys
+import importlib
+from types import SimpleNamespace
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+def test_near_jackpot_delay_range():
+    import bot
+    importlib.reload(bot)
+    class DummyMessage:
+        def __init__(self):
+            self.dice = SimpleNamespace(emoji="🎰", value=2)  # two-of-a-kind
+        async def reply_text(self, text):
+            pass
+
+    update = SimpleNamespace(
+        effective_message=DummyMessage(),
+        effective_user=SimpleNamespace(id=1, full_name="User", username="user"),
+        effective_chat=SimpleNamespace(id=1),
+    )
+    context = SimpleNamespace()
+
+    captured = {}
+
+    def fake_uniform(a, b):
+        captured['range'] = (a, b)
+        return 5.5
+
+    async def fake_sleep(delay):
+        captured['delay'] = delay
+
+    orig_uniform = random.uniform
+    orig_sleep = asyncio.sleep
+    orig_randint = random.randint
+    random.uniform = fake_uniform
+    asyncio.sleep = fake_sleep
+    random.randint = lambda a, b: 1
+    try:
+        asyncio.run(bot.on_dice(update, context))
+    finally:
+        random.uniform = orig_uniform
+        asyncio.sleep = orig_sleep
+        random.randint = orig_randint
+
+    assert captured['range'] == (bot.NEAR_JACKPOT_DELAY_MIN, bot.NEAR_JACKPOT_DELAY_MAX)
+    assert bot.NEAR_JACKPOT_DELAY_MIN <= captured['delay'] <= bot.NEAR_JACKPOT_DELAY_MAX

--- a/tests/test_slot_value.py
+++ b/tests/test_slot_value.py
@@ -1,4 +1,8 @@
 import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import bot
 
 


### PR DESCRIPTION
## Summary
- document near-jackpot random delay behavior
- add random 4.5–10s delay before near-jackpot replies
- test near-jackpot delay range and fix test imports
- expose jackpot and near-jackpot delays via environment variables
- add test for configurable jackpot delay

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f452a5a488329a68d2bd91b953aeb